### PR TITLE
issues/99 - Basic implementation of executions history

### DIFF
--- a/quix-backend/quix-core/pom.xml
+++ b/quix-backend/quix-core/pom.xml
@@ -16,6 +16,9 @@
         <presto.version>326</presto.version>
         <specs.version>4.8.1</specs.version>
         <scala.maven.plugin.version>4.3.0</scala.maven.plugin.version>
+        <wix.embedded.mysql.version>4.6.1</wix.embedded.mysql.version>
+        <mysql.connector.version>8.0.18</mysql.connector.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
 
     <dependencies>
@@ -95,6 +98,29 @@
             <groupId>org.specs2</groupId>
             <artifactId>specs2-mock_${scala.dependencies.version}</artifactId>
             <version>${specs.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.wix/wix-embedded-mysql -->
+        <dependency>
+            <groupId>com.wix</groupId>
+            <artifactId>wix-embedded-mysql</artifactId>
+            <version>${wix.embedded.mysql.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.connector.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/quix-backend/quix-core/src/main/scala/quix/core/history/Execution.scala
+++ b/quix-backend/quix-core/src/main/scala/quix/core/history/Execution.scala
@@ -1,0 +1,20 @@
+package quix.core.history
+
+import java.time.Instant
+
+import quix.api.users.User
+
+case class Execution(id: String,
+                     queryType: String,
+                     statements: Seq[String],
+                     user: User,
+                     startedAt: Instant,
+                     status: ExecutionStatus)
+
+sealed trait ExecutionStatus
+
+object ExecutionStatus {
+  case object Running extends ExecutionStatus
+  case object Finished extends ExecutionStatus
+  case object Failed extends ExecutionStatus
+}

--- a/quix-backend/quix-core/src/main/scala/quix/core/history/HistoryBuilder.scala
+++ b/quix-backend/quix-core/src/main/scala/quix/core/history/HistoryBuilder.scala
@@ -1,0 +1,43 @@
+package quix.core.history
+
+import cats.syntax.apply._
+import monix.eval.Task
+import quix.api.execute.{ActiveQuery, Builder}
+import quix.core.history.dao.HistoryWriteDao
+
+class HistoryBuilder[Results](delegate: Builder[String, Results],
+                              historyWriteDao: HistoryWriteDao,
+                              queryType: String)
+  extends Builder[String, Results] {
+
+  override def start(query: ActiveQuery[String]): Task[Unit] =
+    delegate.start(query) *> historyWriteDao.executionStarted(query, queryType)
+
+  override def end(query: ActiveQuery[String]): Task[Unit] =
+    delegate.end(query) *> historyWriteDao.executionSucceeded(query.id)
+
+  override def error(queryId: String, e: Throwable): Task[Unit] =
+    delegate.error(queryId, e) *> historyWriteDao.executionFailed(queryId, e)
+
+  override def rowCount: Long =
+    delegate.rowCount
+
+  override def lastError: Option[Throwable] =
+    delegate.lastError
+
+  override def startSubQuery(queryId: String, code: String, results: Results): Task[Unit] =
+    delegate.startSubQuery(queryId, code, results)
+
+  override def addSubQuery(queryId: String, results: Results): Task[Unit] =
+    delegate.addSubQuery(queryId, results)
+
+  override def endSubQuery(queryId: String): Task[Unit] =
+    delegate.endSubQuery(queryId)
+
+  override def errorSubQuery(queryId: String, e: Throwable): Task[Unit] =
+    delegate.errorSubQuery(queryId, e)
+
+  override def log(queryId: String, line: String, level: String): Task[Unit] =
+    delegate.log(queryId, line, level)
+
+}

--- a/quix-backend/quix-core/src/main/scala/quix/core/history/dao/HistoryReadDao.scala
+++ b/quix-backend/quix-core/src/main/scala/quix/core/history/dao/HistoryReadDao.scala
@@ -1,0 +1,56 @@
+package quix.core.history.dao
+
+import monix.eval.Task
+import quix.core.history.{Execution, ExecutionStatus}
+
+trait HistoryReadDao {
+  def executions(filter: Filter = Filter.None,
+                 sort: Sort = Sort.Default,
+                 page: Page = Page.First): Task[List[Execution]]
+}
+
+sealed trait Filter
+
+object Filter {
+  case object None extends Filter
+  case class Status(status: ExecutionStatus) extends Filter
+}
+
+case class Sort(by: SortField, order: SortOrder)
+
+object Sort {
+  val Default = Sort(SortField.StartTime, SortOrder.Descending)
+}
+
+sealed trait SortField
+
+object SortField {
+  case object StartTime extends SortField
+}
+
+sealed trait SortOrder
+
+object SortOrder {
+  case object Ascending extends SortOrder
+  case object Descending extends SortOrder
+}
+
+trait Page {
+  def offset: Int
+  def limit: Int
+}
+
+object Page {
+  val DefaultLimit = 20
+  val MaxLimit = 1000
+  val First = Page(0, DefaultLimit)
+
+  def apply(offset: Int, limit: Int): Page = {
+    val offset1 = offset max 0
+    val limit1 = limit min MaxLimit
+    new Page {
+      override val offset: Int = offset1
+      override val limit: Int = limit1
+    }
+  }
+}

--- a/quix-backend/quix-core/src/main/scala/quix/core/history/dao/HistoryReadDao.scala
+++ b/quix-backend/quix-core/src/main/scala/quix/core/history/dao/HistoryReadDao.scala
@@ -38,6 +38,7 @@ object SortOrder {
 trait Page {
   def offset: Int
   def limit: Int
+  def endOffset: Int = offset + limit
 }
 
 object Page {

--- a/quix-backend/quix-core/src/main/scala/quix/core/history/dao/HistoryWriteDao.scala
+++ b/quix-backend/quix-core/src/main/scala/quix/core/history/dao/HistoryWriteDao.scala
@@ -1,0 +1,10 @@
+package quix.core.history.dao
+
+import monix.eval.Task
+import quix.api.execute.ActiveQuery
+
+trait HistoryWriteDao {
+  def executionStarted(query: ActiveQuery[String], queryType: String): Task[Unit]
+  def executionSucceeded(queryId: String): Task[Unit]
+  def executionFailed(queryId: String, error: Throwable): Task[Unit]
+}

--- a/quix-backend/quix-core/src/main/scala/quix/core/history/dao/InMemoryHistoryDao.scala
+++ b/quix-backend/quix-core/src/main/scala/quix/core/history/dao/InMemoryHistoryDao.scala
@@ -1,0 +1,64 @@
+package quix.core.history.dao
+
+import java.time.Clock
+
+import cats.effect.concurrent.Ref
+import monix.eval.Task
+import quix.api.execute.ActiveQuery
+import quix.core.history.{Execution, ExecutionStatus}
+
+case class InMemoryHistoryDao(state: Ref[Task, Map[String, Execution]], clock: Clock)
+  extends HistoryWriteDao with HistoryReadDao {
+
+  private val instant = Task(clock.instant)
+
+  override def executionStarted(query: ActiveQuery[String], queryType: String): Task[Unit] =
+    instant.flatMap { now =>
+      val execution = Execution(
+        id = query.id,
+        queryType = queryType,
+        statements = query.statements,
+        user = query.user,
+        startedAt = now,
+        status = ExecutionStatus.Running)
+
+      state.update(_ + (query.id -> execution))
+    }
+
+  override def executionSucceeded(queryId: String): Task[Unit] =
+    update(queryId, _.copy(status = ExecutionStatus.Finished))
+
+  override def executionFailed(queryId: String, error: Throwable): Task[Unit] =
+    update(queryId, _.copy(status = ExecutionStatus.Failed))
+
+  override def executions(filter: Filter, sort: Sort, page: Page): Task[List[Execution]] =
+    state.get.map { map =>
+      map.values
+        .toList
+        .filter { execution =>
+          filter match {
+            case Filter.None => true
+            case Filter.Status(status) => execution.status == status
+          }
+        }
+        .sortBy { execution =>
+          sort.by match {
+            case SortField.StartTime => execution.startedAt
+          }
+        }
+        .slice(page.offset, page.offset + page.limit)
+    }
+
+  private def update(queryId: String, f: Execution => Execution): Task[Unit] =
+    state.update { map =>
+      map.get(queryId).fold(map) { execution =>
+        map + (queryId -> f(execution))
+      }
+    }
+
+}
+
+object InMemoryHistoryDao {
+  def make(clock: Clock): Task[InMemoryHistoryDao] =
+    Ref.of[Task, Map[String, Execution]](Map.empty).map(InMemoryHistoryDao(_, clock))
+}

--- a/quix-backend/quix-core/src/main/scala/quix/core/history/dao/MySqlHistoryDao.scala
+++ b/quix-backend/quix-core/src/main/scala/quix/core/history/dao/MySqlHistoryDao.scala
@@ -1,0 +1,143 @@
+package quix.core.history.dao
+import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
+import java.time.{Clock, Instant}
+
+import cats.effect.Resource
+import cats.syntax.apply._
+import monix.eval.Task
+import quix.api.execute.ActiveQuery
+import quix.api.users.User
+import quix.core.history.dao.MySqlHistoryDao._
+import quix.core.history.{Execution, ExecutionStatus}
+
+class MySqlHistoryReadDao(connection: Connection) extends HistoryReadDao {
+
+  override def executions(filter: Filter, sort: Sort, page: Page): Task[List[Execution]] = {
+    val insertStatement = prepare(connection) {
+      s"""
+        SELECT id, query_type, statements, user_id, user_email, created_at, status
+        FROM executions_history
+        ${where(filter)}
+        ${orderBy(sort)}
+        LIMIT ?, ?
+      """
+    }
+
+    insertStatement.use { statement =>
+      for {
+        _ <- Task(statement.setInt(1, page.offset))
+        _ <- Task(statement.setInt(2, page.limit))
+        rows <- Task(statement.executeQuery()).bracket(getRows(getExecution))(rs => Task(rs.close()))
+      } yield rows.reverse
+    }
+  }
+
+  private def where(filter: Filter): String = filter match {
+    case Filter.Status(status) => s"WHERE status = '${status.toString.toUpperCase}'"
+    case Filter.None => ""
+  }
+
+  private def orderBy(sort: Sort): String =
+    s"ORDER BY ${field(sort.by)} ${order(sort.order)}"
+
+  private def field(sortField: SortField): String = sortField match {
+    case SortField.StartTime => "created_at"
+  }
+
+  private def order(sortOrder: SortOrder): String = sortOrder match {
+    case SortOrder.Descending => "DESC"
+    case SortOrder.Ascending => "ASC"
+  }
+
+  private def getRows[A](getRow: ResultSet => Task[A])(resultSet: ResultSet): Task[List[A]] = {
+    Task(resultSet.next()).flatMapLoop(List.empty[A]) { (hasRow, rows, continue) =>
+      if (hasRow) getRow(resultSet).flatMap(row => continue(row :: rows))
+      else Task.now(rows)
+    }
+  }
+
+  private def getExecution(resultSet: ResultSet): Task[Execution] = for {
+    id <- Task(resultSet.getString("id"))
+    queryType <- Task(resultSet.getString("query_type"))
+    statements <- Task(resultSet.getString("statements"))
+    userEmail <- Task(resultSet.getString("user_email"))
+    userId <- Task(resultSet.getString("user_id"))
+    createdAt <- Task(resultSet.getLong("created_at"))
+    status <- Task(resultSet.getString("status"))
+  } yield Execution(
+    id = id,
+    queryType = queryType,
+    statements = statements.split(separator),
+    user = User(userEmail, userId),
+    startedAt = Instant.ofEpochMilli(createdAt),
+    status = statusFrom(status))
+
+  private def statusFrom(status: String): ExecutionStatus = status match {
+    case "RUNNING" => ExecutionStatus.Running
+    case "FINISHED" => ExecutionStatus.Finished
+    case _ => ExecutionStatus.Failed
+  }
+
+}
+
+class MySqlHistoryWriteDao(connection: Connection, clock: Clock) extends HistoryWriteDao {
+
+  private val instant = Task(clock.instant())
+
+  private val startStatement = prepare(connection) {
+    """
+      INSERT INTO executions_history (id, query_type, statements, user_id, user_email, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    """
+  }
+
+  private val succeedStatement = prepare(connection) {
+    "UPDATE executions_history SET status = 'FINISHED' WHERE id = ? LIMIT 1"
+  }
+
+  private val failStatement = prepare(connection) {
+    "UPDATE executions_history SET status = 'FAILED' WHERE id = ? LIMIT 1"
+  }
+
+  override def executionStarted(query: ActiveQuery[String], queryType: String): Task[Unit] =
+    startStatement.use { statement =>
+      for {
+        now <- instant
+        _ <- Task(statement.setString(1, query.id))
+        _ <- Task(statement.setString(2, queryType))
+        // TODO - this is not a good way to save multiple statements, better use a JSON list
+        _ <- Task(statement.setString(3, query.statements.mkString(separator)))
+        _ <- Task(statement.setString(4, query.user.id))
+        _ <- Task(statement.setString(5, query.user.email))
+        _ <- Task(statement.setLong(6, now.toEpochMilli))
+        _ <- Task(statement.executeUpdate())
+      } yield ()
+    }
+
+  override def executionSucceeded(queryId: String): Task[Unit] =
+    succeedStatement.use { statement =>
+      Task(statement.setString(1, queryId)) *>
+        Task(statement.executeUpdate())
+    }
+
+  override def executionFailed(queryId: String, error: Throwable): Task[Unit] =
+    failStatement.use { statement =>
+      Task(statement.setString(1, queryId)) *>
+        Task(statement.executeUpdate())
+    }
+
+}
+
+case class JdbcConfig(url: String, user: String, pass: String)
+
+object MySqlHistoryDao {
+  val separator = ";"
+
+  def connect(config: JdbcConfig): Resource[Task, Connection] = {
+    val acquire = Task(DriverManager.getConnection(config.url, config.user, config.pass))
+    Resource.make(acquire)(connection => Task(connection.close()))
+  }
+
+  def prepare(connection: Connection)(sql: String): Resource[Task, PreparedStatement] =
+    Resource.make(Task(connection.prepareStatement(sql)))(statement => Task(statement.close()))
+}

--- a/quix-backend/quix-core/src/test/resources/db/001_init.sql
+++ b/quix-backend/quix-core/src/test/resources/db/001_init.sql
@@ -1,0 +1,11 @@
+CREATE TABLE executions_history (
+    id CHAR(36) NOT NULL PRIMARY KEY,
+    query_type VARCHAR(64) NOT NULL,
+    statements BLOB NOT NULL,
+    user_id VARCHAR(64) NOT NULL,
+    user_email VARCHAR(64) NOT NULL,
+    status ENUM('RUNNING', 'FINISHED', 'FAILED') NOT NULL DEFAULT 'RUNNING',
+    created_at BIGINT UNSIGNED NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP(),
+    INDEX published_forms (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/ExecutionMatchers.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/ExecutionMatchers.scala
@@ -1,0 +1,12 @@
+package quix.core.history
+
+import org.specs2.matcher.Matcher
+import org.specs2.matcher.Matchers._
+
+object ExecutionMatchers {
+  def executionWithId(id: String): Matcher[Execution] =
+    equalTo(id) ^^ ((_: Execution).id)
+
+  def executionWithStatus(status: ExecutionStatus): Matcher[Execution] =
+    equalTo(status) ^^ ((_: Execution).status)
+}

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/FakeBuilder.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/FakeBuilder.scala
@@ -1,0 +1,117 @@
+package quix.core.history
+
+import cats.effect.concurrent.Ref
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import quix.api.execute.{ActiveQuery, Batch, Builder}
+
+case class FakeBuilder(state: Ref[Task, State]) extends Builder[String, Batch] {
+
+  override def start(query: ActiveQuery[String]): Task[Unit] =
+    state.update(_.start(query))
+
+  override def end(query: ActiveQuery[String]): Task[Unit] =
+    state.update(_.end(query))
+
+  override def error(queryId: String, e: Throwable): Task[Unit] =
+    state.update(_.error(queryId, e))
+
+  override def rowCount: Long = get(_.rows)
+
+  override def lastError: Option[Throwable] = get(_.lastError)
+
+  override def startSubQuery(queryId: String, code: String, results: Batch): Task[Unit] =
+    state.update(_.startSubQuery(queryId, code, results))
+
+  override def addSubQuery(queryId: String, results: Batch): Task[Unit] =
+    state.update(_.addSubQuery(queryId, results))
+
+  override def endSubQuery(queryId: String): Task[Unit] =
+    state.update(_.endSubQuery(queryId))
+
+  override def errorSubQuery(queryId: String, e: Throwable): Task[Unit] =
+    state.update(_.error(queryId, e))
+
+  override def log(queryId: String, line: String, level: String): Task[Unit] =
+    state.update(_.addLogLine(queryId, line, level))
+
+  private def get[A](f: State => A): A =
+    state.get.map(f).runSyncUnsafe()
+
+}
+
+object FakeBuilder {
+  def make: Task[FakeBuilder] =
+    Ref.of[Task, State](State.Empty).map(FakeBuilder(_))
+}
+
+case class State(queries: Map[String, Query],
+                 subQueries: Map[String, SubQuery],
+                 errors: List[Error],
+                 log: List[LogLine]) {
+
+  def rows: Long = subQueries.values.foldLeft(0L)(_ + _.rows)
+
+  def start(query: ActiveQuery[String]): State =
+    copy(queries = queries + (query.id -> Query(query, QueryStatus.Started)))
+
+  def end(query: ActiveQuery[String]): State =
+    copy(queries = queries + (query.id -> Query(query, QueryStatus.Ended)))
+
+  def error(queryId: String, e: Throwable): State =
+    copy(errors = Error(queryId, e) :: errors)
+
+  def lastError: Option[Throwable] =
+    errors.headOption.map(_.error)
+
+  def startSubQuery(queryId: String, code: String, results: Batch): State =
+    copy(subQueries = subQueries + (queryId -> SubQuery(code, results)))
+
+  def addSubQuery(queryId: String, results: Batch): State =
+    copy(subQueries = updateSubQuery(queryId, _.addResults(results)))
+
+  def endSubQuery(queryId: String): State =
+    copy(subQueries = updateSubQuery(queryId, _.ended))
+
+  def addLogLine(queryId: String, line: String, level: String): State =
+    copy(log = LogLine(queryId, line, level) :: log)
+
+  private def updateSubQuery(queryId: String, f: SubQuery => SubQuery): Map[String, SubQuery] =
+    subQueries.get(queryId).fold(subQueries)(query => subQueries + (queryId -> f(query)))
+}
+
+object State {
+  val Empty = State(Map.empty, Map.empty, Nil, Nil)
+}
+
+sealed trait QueryStatus
+
+object QueryStatus {
+  case object Started extends QueryStatus
+  case object Ended extends QueryStatus
+}
+
+case class Query(query: ActiveQuery[String], status: QueryStatus)
+
+case class SubQuery(code: String,
+                    results: List[Batch],
+                    status: QueryStatus) {
+
+  def rows: Long = results.foldLeft(0L)(_ + _.data.size)
+
+  def addResults(moreResults: Batch): SubQuery =
+    copy(results = moreResults :: results)
+
+  def ended: SubQuery =
+    copy(status = QueryStatus.Ended)
+
+}
+
+object SubQuery {
+  def apply(code: String, results: Batch): SubQuery =
+    SubQuery(code, List(results), QueryStatus.Started)
+}
+
+case class Error(queryId: String, error: Throwable)
+
+case class LogLine(queryId: String, line: String, level: String)

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/FakeClock.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/FakeClock.scala
@@ -1,0 +1,23 @@
+package quix.core.history
+
+import java.time.{Clock, Instant, ZoneId, ZoneOffset}
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.duration.FiniteDuration
+
+case class FakeClock(now: AtomicReference[Instant],
+                     getZone: ZoneId) extends Clock {
+
+  override def withZone(zone: ZoneId): Clock = copy(getZone = zone)
+
+  override def instant: Instant = now.get
+
+  def sleep(duration: FiniteDuration): Unit =
+    now.updateAndGet(_.plusMillis(duration.toMillis))
+
+}
+
+object FakeClock {
+  def apply(now: Instant, zone: ZoneId = ZoneOffset.UTC): FakeClock =
+    FakeClock(new AtomicReference(now), zone)
+}

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/HistoryBuilderTest.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/HistoryBuilderTest.scala
@@ -1,0 +1,91 @@
+package quix.core.history
+
+import java.time.{Clock, Instant, ZoneOffset}
+
+import monix.execution.Scheduler.Implicits.global
+import org.specs2.mutable.SpecificationWithJUnit
+import quix.api.execute.{ActiveQuery, Batch}
+import quix.api.users.User
+import quix.core.history.ExecutionMatchers._
+import quix.core.history.HistoryBuilderTest._
+import quix.core.history.dao.InMemoryHistoryDao
+
+class HistoryBuilderTest extends SpecificationWithJUnit {
+
+  val subQuery = "query3"
+  val now = Instant.ofEpochMilli(0)
+  val clock = Clock.fixed(now, ZoneOffset.UTC)
+  val makeDao = InMemoryHistoryDao.make(clock)
+
+  "delegate calls to internal builder" in {
+    val result = for {
+      delegate <- FakeBuilder.make
+      dao <- makeDao
+      builder = new HistoryBuilder(delegate, dao, queryType)
+      _ <- builder.start(query1)
+      _ <- builder.startSubQuery(subQuery, code1, batch1)
+      _ <- builder.addSubQuery(subQuery, batch2)
+      _ <- builder.endSubQuery(subQuery)
+      _ <- builder.end(query1)
+      _ <- builder.start(query2)
+      _ <- builder.log(query2.id, "some-log")
+      _ <- builder.error(query2.id, error1)
+      _ <- builder.errorSubQuery(subQuery, error2)
+      state <- delegate.state.get
+    } yield state
+
+    result.runSyncUnsafe() must
+      equalTo(
+        State(
+          queries = Map(
+            query1.id -> Query(query1, QueryStatus.Ended),
+            query2.id -> Query(query2, QueryStatus.Started)),
+          subQueries = Map(subQuery -> SubQuery(code1, List(batch2, batch1), QueryStatus.Ended)),
+          errors = List(Error(subQuery, error2), Error(query2.id, error1)),
+          log = List(LogLine(query2.id, "some-log", "INFO"))))
+  }
+
+  "persist execution history" in {
+    val result = for {
+      delegate <- FakeBuilder.make
+      dao <- makeDao
+      builder = new HistoryBuilder(delegate, dao, queryType)
+      _ <- builder.start(query1)
+      _ <- builder.end(query1)
+      executions <- dao.executions()
+    } yield executions
+
+    result.runSyncUnsafe() must
+      contain(executionWithStatus(ExecutionStatus.Finished))
+  }
+
+  "persist failed execution" in {
+    val error = new RuntimeException("oops")
+    val result = for {
+      delegate <- FakeBuilder.make
+      dao <- makeDao
+      builder = new HistoryBuilder(delegate, dao, queryType)
+      _ <- builder.start(query1)
+      _ <- builder.error(query1.id, error)
+      executions <- dao.executions()
+    } yield executions
+
+    result.runSyncUnsafe() must
+      contain(executionWithStatus(ExecutionStatus.Failed))
+  }
+
+}
+
+object HistoryBuilderTest {
+  val user = User("foo@bar.com", "some-user")
+  val code1 = "code1"
+  val code2 = "code2"
+  val code3 = "code3"
+  val queryType = "query-type"
+  val query1 = ActiveQuery("query1", List(code1, code2), user)
+  val query2 = ActiveQuery("query2", List(code3), user)
+  val batch1 = Batch(List(List(1), List(2)))
+  val batch2 = Batch(List(List(3)))
+  val error1 = new RuntimeException("foo")
+  val error2 = new RuntimeException("bar")
+}

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/dao/HistoryDaoContractTest.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/dao/HistoryDaoContractTest.scala
@@ -1,0 +1,128 @@
+package quix.core.history.dao
+
+import java.time.Instant
+
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.specs2.mutable.SpecificationWithJUnit
+import quix.api.execute.ActiveQuery
+import quix.api.users.User
+import quix.core.history.ExecutionMatchers._
+import quix.core.history.dao.HistoryDaoContractTest._
+import quix.core.history.{Execution, ExecutionStatus}
+
+trait HistoryDaoContractTest extends SpecificationWithJUnit {
+
+  def createDao: Task[HistoryWriteDao with HistoryReadDao]
+
+  "return empty list of executions if none was saved" in {
+    val result = for {
+      dao <- createDao
+      executions <- dao.executions()
+    } yield executions
+
+    result.runSyncUnsafe() must beEmpty
+  }
+
+  "return running execution" in {
+    val result = for {
+      dao <- createDao
+      _ <- dao.executionStarted(query, queryType)
+      executions <- dao.executions()
+    } yield executions
+
+    result.runSyncUnsafe() must contain(
+      Execution(
+        id = "query-id",
+        queryType = queryType,
+        statements = statements,
+        user = user,
+        startedAt = now,
+        status = ExecutionStatus.Running))
+  }
+
+  "return succeeded execution" in {
+    val result = for {
+      dao <- createDao
+      _ <- dao.executionStarted(query, queryType)
+      _ <- dao.executionSucceeded(queryId)
+      executions <- dao.executions()
+    } yield executions
+
+    result.runSyncUnsafe() must
+      contain(executionWithStatus(ExecutionStatus.Finished))
+  }
+
+  "return failed execution" in {
+    val error = new RuntimeException("oops")
+    val result = for {
+      dao <- createDao
+      _ <- dao.executionStarted(query, queryType)
+      _ <- dao.executionFailed(queryId, error)
+      executions <- dao.executions()
+    } yield executions
+
+    result.runSyncUnsafe() must
+      contain(executionWithStatus(ExecutionStatus.Failed))
+  }
+
+  "support paging" in {
+    val query1 = query.copy(id = "query-1")
+    val query2 = query.copy(id = "query-2")
+    val query3 = query.copy(id = "query-3")
+    val query4 = query.copy(id = "query-4")
+    val query5 = query.copy(id = "query-5")
+
+    val result = for {
+      dao <- createDao
+      _ <- dao.executionStarted(query1, queryType)
+      _ <- dao.executionStarted(query2, queryType)
+      _ <- dao.executionStarted(query3, queryType)
+      _ <- dao.executionStarted(query4, queryType)
+      _ <- dao.executionStarted(query5, queryType)
+      page1 <- dao.executions(page = Page(0, 3))
+      page2 <- dao.executions(page = Page(3, 3))
+    } yield (page1, page2)
+
+    result.runSyncUnsafe() must beLike {
+      case (page1, page2) =>
+        (page1 must contain(exactly(executionWithId(query1.id), executionWithId(query2.id), executionWithId(query3.id)))) and
+          (page2 must contain(exactly(executionWithId(query4.id), executionWithId(query5.id))))
+    }
+  }
+
+  "support filtering by status" in {
+    val query1 = query.copy(id = "query-1")
+    val query2 = query.copy(id = "query-2")
+    val query3 = query.copy(id = "query-3")
+
+    val result = for {
+      dao <- createDao
+      _ <- dao.executionStarted(query1, queryType)
+      _ <- dao.executionStarted(query2, queryType)
+      _ <- dao.executionStarted(query3, queryType)
+      _ <- dao.executionSucceeded(query2.id)
+      _ <- dao.executionFailed(query3.id, new RuntimeException)
+      running <- dao.executions(filter = Filter.Status(ExecutionStatus.Running))
+      finished <- dao.executions(filter = Filter.Status(ExecutionStatus.Finished))
+      failed <- dao.executions(filter = Filter.Status(ExecutionStatus.Failed))
+    } yield (running, finished, failed)
+
+    result.runSyncUnsafe() must beLike {
+      case (running, finished, failed) =>
+        (running must contain(exactly(executionWithId(query1.id)))) and
+          (finished must contain(exactly(executionWithId(query2.id)))) and
+          (failed must contain(exactly(executionWithId(query3.id))))
+    }
+  }
+
+}
+
+object HistoryDaoContractTest {
+  val now = Instant.ofEpochMilli(0)
+  val queryType = "query-type"
+  val user = User("foo@bar.com", "some-user")
+  val statements = List("code1", "code2")
+  val queryId = "query-id"
+  val query = ActiveQuery(queryId, statements, user)
+}

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/dao/InMemoryHistoryDaoTest.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/dao/InMemoryHistoryDaoTest.scala
@@ -1,13 +1,12 @@
 package quix.core.history.dao
 
-import java.time.{Clock, ZoneOffset}
+import java.time.Clock
 
 import monix.eval.Task
-import quix.core.history.dao.HistoryDaoContractTest._
 
 class InMemoryHistoryDaoTest extends HistoryDaoContractTest {
 
-  override def createDao: Task[HistoryWriteDao with HistoryReadDao] =
-    InMemoryHistoryDao.make(Clock.fixed(now, ZoneOffset.UTC))
+  override def createDao(clock: Clock): Task[HistoryWriteDao with HistoryReadDao] =
+    InMemoryHistoryDao.make(clock)
 
 }

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/dao/InMemoryHistoryDaoTest.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/dao/InMemoryHistoryDaoTest.scala
@@ -2,11 +2,12 @@ package quix.core.history.dao
 
 import java.time.Clock
 
+import cats.effect.Resource
 import monix.eval.Task
 
 class InMemoryHistoryDaoTest extends HistoryDaoContractTest {
 
-  override def createDao(clock: Clock): Task[HistoryWriteDao with HistoryReadDao] =
-    InMemoryHistoryDao.make(clock)
+  override def createDao(clock: Clock): Resource[Task, HistoryWriteDao with HistoryReadDao] =
+    Resource.liftF(InMemoryHistoryDao.make(clock))
 
 }

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/dao/InMemoryHistoryDaoTest.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/dao/InMemoryHistoryDaoTest.scala
@@ -1,0 +1,13 @@
+package quix.core.history.dao
+
+import java.time.{Clock, ZoneOffset}
+
+import monix.eval.Task
+import quix.core.history.dao.HistoryDaoContractTest._
+
+class InMemoryHistoryDaoTest extends HistoryDaoContractTest {
+
+  override def createDao: Task[HistoryWriteDao with HistoryReadDao] =
+    InMemoryHistoryDao.make(Clock.fixed(now, ZoneOffset.UTC))
+
+}

--- a/quix-backend/quix-core/src/test/scala/quix/core/history/dao/MySqlHistoryDaoTest.scala
+++ b/quix-backend/quix-core/src/test/scala/quix/core/history/dao/MySqlHistoryDaoTest.scala
@@ -1,0 +1,88 @@
+package quix.core.history.dao
+import java.time.Clock
+
+import cats.effect.Resource
+import com.typesafe.scalalogging.LazyLogging
+import com.wix.mysql.EmbeddedMysql
+import com.wix.mysql.EmbeddedMysql.anEmbeddedMysql
+import com.wix.mysql.ScriptResolver.classPathScript
+import com.wix.mysql.config.Charset.UTF8
+import com.wix.mysql.config.MysqldConfig.aMysqldConfig
+import com.wix.mysql.distribution.Version.v5_6_23
+import monix.eval.Task
+import org.specs2.specification.{AfterAll, BeforeAll, BeforeEach}
+import quix.api.execute.ActiveQuery
+import quix.core.history.Execution
+
+class MySqlHistoryDaoTest
+  extends HistoryDaoContractTest
+    with BeforeAll
+    with BeforeEach
+    with AfterAll {
+
+  sequential
+
+  def beforeAll(): Unit = EmbeddedMysqlDb.start()
+
+  def before(): Unit = EmbeddedMysqlDb.reloadSchema()
+
+  def afterAll(): Unit = EmbeddedMysqlDb.stop()
+
+  override def createDao(clock: Clock): Resource[Task, HistoryWriteDao with HistoryReadDao] =
+    MySqlHistoryDao.connect(EmbeddedMysqlDb.Config).map { connection =>
+      val reader = new MySqlHistoryReadDao(connection)
+      val writer = new MySqlHistoryWriteDao(connection, clock)
+      new HistoryWriteDao with HistoryReadDao {
+        override def executionStarted(query: ActiveQuery[String], queryType: String): Task[Unit] =
+          writer.executionStarted(query, queryType)
+
+        override def executionSucceeded(queryId: String): Task[Unit] =
+          writer.executionSucceeded(queryId)
+
+        override def executionFailed(queryId: String, error: Throwable): Task[Unit] =
+          writer.executionFailed(queryId, error)
+
+        override def executions(filter: Filter, sort: Sort, page: Page): Task[List[Execution]] =
+          reader.executions(filter, sort, page)
+      }
+    }
+
+}
+
+object EmbeddedMysqlDb extends LazyLogging {
+  Class.forName("com.mysql.cj.jdbc.Driver")
+
+  private val port = 2215
+
+  private val user = "wix"
+
+  private val pass = "wix"
+
+  private val schema = "aschema"
+
+  private var db: EmbeddedMysql = _
+
+  val Config = JdbcConfig(s"jdbc:mysql://localhost:$port/$schema", user, pass)
+
+  def reloadSchema(): Unit = {
+    logger.info("method=reloadSchema")
+    db.reloadSchema(schema, classPathScript("db/001_init.sql"))
+  }
+
+  def stop(): Unit = {
+    logger.info("method=stop")
+    db.stop()
+  }
+
+  def start(): Unit = {
+    logger.info("method=start")
+    db = anEmbeddedMysql(
+      aMysqldConfig(v5_6_23)
+        .withCharset(UTF8)
+        .withPort(port)
+        .withUser(user, pass)
+        .build())
+      .addSchema(schema, classPathScript("db/001_init.sql"))
+      .start()
+  }
+}

--- a/quix-backend/quix-modules/quix-athena-module/src/main/scala/quix/athena/TryAthena.scala
+++ b/quix-backend/quix-modules/quix-athena-module/src/main/scala/quix/athena/TryAthena.scala
@@ -4,13 +4,10 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.athena.AmazonAthenaClient
 import com.typesafe.scalalogging.LazyLogging
-import monix.execution.Scheduler
+import monix.execution.Scheduler.Implicits.global
 import quix.api.execute.ActiveQuery
 import quix.api.users.User
 import quix.core.results.SingleBuilder
-
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 
 object TryAthena extends LazyLogging {
   def main(args: Array[String]): Unit = {
@@ -28,7 +25,7 @@ object TryAthena extends LazyLogging {
 
     val task = queryExecutor.runTask(new ActiveQuery[String]("id", Seq("SELECT *\nFROM default.elb_logs\nLIMIT 1000"), User("valeryf")), results)
 
-    Await.ready(task.runToFuture(Scheduler.global), Duration.Inf)
+    task.runSyncUnsafe()
 
     logger.info("results = " + results.build())
   }

--- a/quix-backend/quix-modules/quix-presto-module/src/main/scala/quix/presto/TryPresto.scala
+++ b/quix-backend/quix-modules/quix-presto-module/src/main/scala/quix/presto/TryPresto.scala
@@ -4,14 +4,11 @@ import java.util.UUID
 
 import com.typesafe.scalalogging.LazyLogging
 import monix.eval.Task
-import monix.execution.Scheduler
+import monix.execution.Scheduler.Implicits.global
 import quix.api.execute.ActiveQuery
 import quix.api.users.User
 import quix.core.results.SingleBuilder
 import quix.presto.rest.ScalaJPrestoStateClient
-
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 
 object TryPresto extends LazyLogging {
 
@@ -30,9 +27,7 @@ object TryPresto extends LazyLogging {
       builder = new SingleBuilder[String]
     } yield executor.runTask(query, builder).map(_ => builder)
 
-    val futureResults = Task.sequence(results).runToFuture(Scheduler.global)
-
-    val builders = Await.result(futureResults, Duration.Inf)
+    val builders = Task.sequence(results).runSyncUnsafe()
 
     for {
       (builder, index) <- builders.zipWithIndex

--- a/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/controllers/DownloadController.scala
+++ b/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/controllers/DownloadController.scala
@@ -36,7 +36,7 @@ class DownloadController(val downloadableQueries: DownloadableQueries[String, Ba
 
           payload match {
             case DownloadableRow(values) =>
-              val line = values.map(quote(_)).mkString(",").getBytes(charset)
+              val line = values.map(quote).mkString(",").getBytes(charset)
               outputStream.write(line)
               outputStream.write('\n')
 

--- a/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/controllers/HistoryController.scala
+++ b/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/controllers/HistoryController.scala
@@ -1,0 +1,39 @@
+package quix.web.controllers
+
+import monix.execution.Scheduler.Implicits.global
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation._
+import quix.core.history.Execution
+import quix.core.history.dao.{HistoryReadDao, Page}
+
+@Controller
+@RequestMapping(Array("/api/history"))
+class HistoryController(historyReadDao: HistoryReadDao) {
+
+  @CrossOrigin(origins = Array("*"), allowedHeaders = Array("*"))
+  @RequestMapping(value = Array("/executions"), method = Array(RequestMethod.GET))
+  @ResponseBody
+  def executions(@RequestParam(defaultValue = "0") offset: String,
+                 @RequestParam(defaultValue = "20") limit: String): List[ExecutionDto] =
+    historyReadDao
+      .executions(page = Page(offset.toInt, limit.toInt))
+      .runSyncUnsafe()
+      .map(ExecutionDto(_))
+
+}
+
+case class ExecutionDto(id: String,
+                        email: String,
+                        query: Seq[String],
+                        moduleType: String,
+                        startedAt: String)
+
+object ExecutionDto {
+  def apply(execution: Execution): ExecutionDto =
+    ExecutionDto(
+      id = execution.id,
+      email = execution.user.email,
+      query = execution.statements,
+      moduleType = execution.queryType,
+      startedAt = execution.startedAt.toString)
+}

--- a/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/spring/HistoryDaoConfig.scala
+++ b/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/spring/HistoryDaoConfig.scala
@@ -1,0 +1,18 @@
+package quix.web.spring
+
+import java.time.Clock
+
+import com.typesafe.scalalogging.LazyLogging
+import monix.execution.Scheduler.Implicits.global
+import org.springframework.context.annotation.{Bean, Configuration}
+import quix.core.history.dao.InMemoryHistoryDao
+
+@Configuration
+class HistoryDaoConfig extends LazyLogging {
+
+  @Bean def historyDao: InMemoryHistoryDao = {
+    logger.info("event=[spring-config] bean=[InMemoryHistoryDao]")
+    InMemoryHistoryDao.make(Clock.systemUTC()).runSyncUnsafe()
+  }
+
+}

--- a/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/spring/SpringConfig.scala
+++ b/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/spring/SpringConfig.scala
@@ -21,6 +21,7 @@ import quix.bigquery.db.{BigQueryAutocomplete, BigQueryCatalogs, BigQueryTables}
 import quix.core.db.{RefreshableAutocomplete, RefreshableCatalogs, RefreshableDb}
 import quix.core.download.DownloadableQueriesImpl
 import quix.core.executions.{SequentialExecutions, SqlModule}
+import quix.core.history.dao.HistoryReadDao
 import quix.core.utils.JsonOps
 import quix.jdbc._
 import quix.presto._
@@ -28,7 +29,7 @@ import quix.presto.db.{PrestoAutocomplete, PrestoCatalogs, PrestoTables}
 import quix.presto.rest.ScalaJPrestoStateClient
 import quix.python.{PythonConfig, PythonExecutor, PythonModule}
 import quix.web.auth.{DemoUsers, JwtUsers}
-import quix.web.controllers.{DbController, DownloadController, HealthController}
+import quix.web.controllers.{DbController, DownloadController, HealthController, HistoryController}
 
 import scala.util.control.NonFatal
 
@@ -338,7 +339,7 @@ class DownloadConfiguration extends LazyLogging {
 @Configuration
 class Controllers extends LazyLogging {
 
-  @Bean def initDbController(modules: Map[String, ExecutionModule[String, Batch]]) = {
+  @Bean def initDbController(modules: Map[String, ExecutionModule[String, Batch]]): DbController = {
     logger.info("event=[spring-config] bean=[DbController]")
     new DbController(modules)
   }
@@ -348,7 +349,12 @@ class Controllers extends LazyLogging {
     new DownloadController(downloadableQueries)
   }
 
-  @Bean def initHealthController() = {
+  @Bean def initHistoryController(historyReadDao: HistoryReadDao): HistoryController = {
+    logger.info("event=[spring-config] bean=[HistoryController]")
+    new HistoryController(historyReadDao)
+  }
+
+  @Bean def initHealthController: HealthController = {
     logger.info("event=[spring-config] bean=[HealthController]")
     new HealthController
   }

--- a/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/spring/WebsocketsConfig.scala
+++ b/quix-backend/quix-webapps/quix-web-spring/src/main/scala/quix/web/spring/WebsocketsConfig.scala
@@ -14,6 +14,7 @@ import org.springframework.web.socket.server.support.DefaultHandshakeHandler
 import quix.api.execute.{Batch, DownloadableQueries, ExecutionEvent}
 import quix.api.module.ExecutionModule
 import quix.api.users.Users
+import quix.core.history.dao.HistoryWriteDao
 import quix.web.controllers.SqlStreamingController
 
 @Configuration
@@ -22,9 +23,15 @@ class WebsocketsConfig extends LazyLogging {
 
   @Bean def initSqlStreamingController(users: Users,
                                        modules: Map[String, ExecutionModule[String, Batch]],
-                                       downloadableQueries: DownloadableQueries[String, Batch, ExecutionEvent]) = {
+                                       downloadableQueries: DownloadableQueries[String, Batch, ExecutionEvent],
+                                       historyWriteDao: HistoryWriteDao) = {
     logger.info("event=[spring-config] bean=[PrestoController]")
-    new SqlStreamingController(modules, users, downloadableQueries, Scheduler.io("presto-io"))
+    new SqlStreamingController(
+      modules = modules,
+      users = users,
+      downloads = downloadableQueries,
+      historyWriteDao = historyWriteDao,
+      io = Scheduler.io("presto-io"))
   }
 
   @Bean def initWebSocketPolicy(): WebSocketPolicy = {

--- a/quix-backend/quix-webapps/quix-web-spring/src/test/scala/quix/web/controllers/EmbeddedMySql.scala
+++ b/quix-backend/quix-webapps/quix-web-spring/src/test/scala/quix/web/controllers/EmbeddedMySql.scala
@@ -1,0 +1,24 @@
+package quix.web.controllers
+
+import com.wix.mysql.EmbeddedMysql
+import com.wix.mysql.EmbeddedMysql.anEmbeddedMysql
+import com.wix.mysql.ScriptResolver.classPathScript
+import com.wix.mysql.config.Charset.UTF8
+import com.wix.mysql.config.MysqldConfig
+import com.wix.mysql.config.MysqldConfig.aMysqldConfig
+import com.wix.mysql.distribution.Version.v5_6_23
+
+object EmbeddedMySql {
+  def create(port: Int, user: String, pass: String): EmbeddedMysql.Builder = {
+    val config: MysqldConfig = aMysqldConfig(v5_6_23)
+      .withCharset(UTF8)
+      .withPort(port)
+      .withUser(user, pass)
+      .build()
+
+    val embeddedServer: EmbeddedMysql.Builder = anEmbeddedMysql(config)
+      .addSchema("aschema", classPathScript("db/001_init.sql"))
+
+    embeddedServer
+  }
+}

--- a/quix-backend/quix-webapps/quix-web-spring/src/test/scala/quix/web/controllers/HistoryControllerTest.scala
+++ b/quix-backend/quix-webapps/quix-web-spring/src/test/scala/quix/web/controllers/HistoryControllerTest.scala
@@ -1,0 +1,47 @@
+package quix.web.controllers
+
+import com.typesafe.scalalogging.LazyLogging
+import com.wix.mysql.ScriptResolver.classPathScript
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.junit.runner.RunWith
+import org.junit.{After, Before, Test}
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit4.SpringRunner
+import quix.web.E2EContext
+import quix.web.spring.SpringConfig
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[SpringRunner])
+@DirtiesContext
+@SpringBootTest(webEnvironment = DEFINED_PORT, classes = Array(classOf[SpringConfig]))
+@TestPropertySource(locations = Array("classpath:test.properties"))
+class HistoryControllerTest extends E2EContext with LazyLogging {
+
+  private val prod = EmbeddedMySql.create(2222, "prod-user", "prod-pass").start()
+
+  @Before
+  def before(): Unit = {
+    prod.reloadSchema("aschema", classPathScript("db/001_init.sql"))
+  }
+
+  @After
+  def after(): Unit = {
+    prod.stop()
+  }
+
+  @Test(timeout = 30000)
+  def listExecutionsHistory(): Unit = {
+    val query = "select * from small_table"
+    execute(query, module = "prod")
+
+    val records = get[List[ExecutionDto]]("api/history/executions")
+
+    assertThat(records.head.query.asJava, Matchers.contains(query))
+  }
+
+}

--- a/quix-backend/quix-webapps/quix-web-spring/src/test/scala/quix/web/controllers/JdbcSqlStreamingControllerTest.scala
+++ b/quix-backend/quix-webapps/quix-web-spring/src/test/scala/quix/web/controllers/JdbcSqlStreamingControllerTest.scala
@@ -1,13 +1,7 @@
 package quix.web.controllers
 
 import com.typesafe.scalalogging.LazyLogging
-import com.wix.mysql.EmbeddedMysql
-import com.wix.mysql.EmbeddedMysql.anEmbeddedMysql
 import com.wix.mysql.ScriptResolver.classPathScript
-import com.wix.mysql.config.Charset.UTF8
-import com.wix.mysql.config.MysqldConfig
-import com.wix.mysql.config.MysqldConfig.aMysqldConfig
-import com.wix.mysql.distribution.Version.v5_6_23
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.hamcrest.text.MatchesPattern.matchesPattern
@@ -19,8 +13,8 @@ import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.context.{TestContextManager, TestPropertySource}
 import quix.web.E2EContext
+import quix.web.controllers.MyMatchers._
 import quix.web.spring.SpringConfig
-import MyMatchers._
 
 @RunWith(classOf[SpringRunner])
 @DirtiesContext
@@ -28,24 +22,10 @@ import MyMatchers._
 @TestPropertySource(locations = Array("classpath:test.properties"))
 class JdbcSqlStreamingControllerTest extends E2EContext with LazyLogging {
 
-  new TestContextManager(this.getClass).prepareTestInstance(this)
+  new TestContextManager(getClass).prepareTestInstance(this)
 
-  val prod = createEmbeddedMySqlServer(2222, "prod-user", "prod-pass").start()
-  val dev = createEmbeddedMySqlServer(3333, "dev-user", "dev-pass").start()
-
-
-  def createEmbeddedMySqlServer(port: Int, user: String, pass: String) = {
-    val config: MysqldConfig = aMysqldConfig(v5_6_23)
-      .withCharset(UTF8)
-      .withPort(port)
-      .withUser(user, pass)
-      .build()
-
-    val embeddedServer: EmbeddedMysql.Builder = anEmbeddedMysql(config)
-      .addSchema("aschema", classPathScript("db/001_init.sql"))
-
-    embeddedServer
-  }
+  private val prod = EmbeddedMySql.create(2222, "prod-user", "prod-pass").start()
+  private val dev = EmbeddedMySql.create(3333, "dev-user", "dev-pass").start()
 
   @Before
   def before(): Unit = {


### PR DESCRIPTION
Beginning of work on #99 

Exposed via `/api/history/executions` API

Currently simple in-memory store, need to implement persistent DAO to comply with contract tests in `HistoryDaoContractTest`