### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/documentation/website/siteConfig.js
+++ b/documentation/website/siteConfig.js
@@ -21,6 +21,10 @@ const users = [
 ];
 
 const siteConfig = {
+  algolia: {
+    apiKey: '706ea6606dcf22ab4091945383d0cff9',
+    indexName: 'quix',
+  },
   title: 'Quix', // Title for your website.
   tagline: 'An easy-to-use notebook manager',
   // url: 'https://your-docusaurus-test-site.com', // Your website URL


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.