### PR TITLE
Types field points in wrong direction

### DIFF
--- a/quix-frontend/shared/package.json
+++ b/quix-frontend/shared/package.json
@@ -26,7 +26,7 @@
     "*"
   ],
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "index.d.ts",
   "devDependencies": {
     "@types/jest": "^24.0.11",
     "@types/lodash": "^4.14.123",


### PR DESCRIPTION
https://unpkg.com/@wix/quix-shared/package.json `types` field point to `dist/index.d.ts` but actual types are in `index.d.ts` (without `dist`).

https://unpkg.com/@wix/quix-shared@1.0.14/index.d.ts